### PR TITLE
Ensure the editor is visible in Safari

### DIFF
--- a/source/Workspace.mint
+++ b/source/Workspace.mint
@@ -226,7 +226,9 @@ component Workspace {
           }
         </div>
 
-        <iframe::iframe src={previewURL}/>
+        <div>
+          <iframe::iframe src={previewURL}/>
+        </div>
       </div>
     }
   }


### PR DESCRIPTION
Safari does not seem to like an `<iframe>` being a grid item, and thus
the CSS rule, `height: 100%`, seem to ignore the boundaries of grid.
Wrapping the `<iframe>` in a `<div>` solves the problem.

**before**

<img width="2560" alt="before" src="https://user-images.githubusercontent.com/503025/115750498-849a6700-a398-11eb-851c-2238629e3475.png">

**after**

<img width="2560" alt="after" src="https://user-images.githubusercontent.com/503025/115750525-8bc17500-a398-11eb-9f27-0865ae49183c.png">
