### PR TITLE
Tutorial fixes

### DIFF
--- a/source/Lessons/Components/01-Basics.mint
+++ b/source/Lessons/Components/01-Basics.mint
@@ -24,7 +24,7 @@ module Lessons {
         ],
       contents:
         <<#MARKDOWN
-        A **component** is a collection of UI elements which together a serve
+        A **component** is a collection of UI elements which together serve a
         specific function. You can think of buttons, checkboxes, selects, images,
         etc... as components.
 

--- a/source/Lessons/Components/03-Dynamic-Attributes.mint
+++ b/source/Lessons/Components/03-Dynamic-Attributes.mint
@@ -47,12 +47,12 @@ module Lessons {
         ```
 
         When building web apps, it's important to make sure that they're
-        accessible to the broadest possible userbase, including people with
+        accessible to the broadest possible user base, including people with
         (for example) impaired vision or motion, or people without powerful
         hardware or good internet connections.
 
-        for people using screenreaders, or people with slow or flaky internet
         To that end, we should add the `alt` attribute that describes the image
+        for people using screen readers, or people with slow or flaky internet
         connections that can't download the image. Let's add it:
 
         ```mint

--- a/source/Lessons/Components/03-Dynamic-Attributes.mint
+++ b/source/Lessons/Components/03-Dynamic-Attributes.mint
@@ -51,8 +51,8 @@ module Lessons {
         (for example) impaired vision or motion, or people without powerful
         hardware or good internet connections.
 
-        To that end we should add the `alt` attribute that describes the image
         for people using screenreaders, or people with slow or flaky internet
+        To that end, we should add the `alt` attribute that describes the image
         connections that can't download the image. Let's add it:
 
         ```mint

--- a/source/Lessons/Components/04-Styling.mint
+++ b/source/Lessons/Components/04-Styling.mint
@@ -57,7 +57,7 @@ module Lessons {
         Style blocks are like CSS classes, they have a name and can be added to
         any element in the component.
 
-        Styling is a topic so big that it has it's own chapter so stick around
+        Styling is a topic so big that it has its own chapter so stick around
         to learn everything about it!
         MARKDOWN
     }

--- a/source/Lessons/Components/04-Styling.mint
+++ b/source/Lessons/Components/04-Styling.mint
@@ -43,7 +43,7 @@ module Lessons {
         ],
       contents:
         <<#MARKDOWN
-        In HTML you normally put your styles into a `<style>` element. In Mint
+        In HTML, you normally put your styles into a `<style>` element. In Mint
         you put it into `style` blocks.
 
         ```mint
@@ -57,7 +57,7 @@ module Lessons {
         Style blocks are like CSS classes, they have a name and can be added to
         any element in the component.
 
-        Styling is a topic so big that it has its own chapter so stick around
+        Styling is a topic so big that it has its own chapter, so stick around
         to learn everything about it!
         MARKDOWN
     }

--- a/source/Lessons/Components/05-Composition.mint
+++ b/source/Lessons/Components/05-Composition.mint
@@ -78,7 +78,7 @@ module Lessons {
         compiler finds all `.mint` files in your project and parses them
         automatically. Anything in them is available everywhere.
 
-        Also notice that the component name `Nested` is capitalised. This
+        Also notice that the component name `Nested` is capitalized. This
         convention has been adopted to allow us to differentiate between
         user-defined components and regular HTML tags.
        MARKDOWN

--- a/source/Lessons/Components/05-Composition.mint
+++ b/source/Lessons/Components/05-Composition.mint
@@ -68,7 +68,7 @@ module Lessons {
         Instead, we can write components in other files and use them as we
         would other elements.
 
-        Once your component is ready all you need to do is add it as markup:
+        Once your component is ready, all you need to do is add it as markup:
 
         ```mint
         <Nested/>

--- a/source/Lessons/Components/06-Properties.mint
+++ b/source/Lessons/Components/06-Properties.mint
@@ -60,7 +60,7 @@ module Lessons {
         * Properties can be referenced by name within the component (in styles,
           functions, computed properties, etc...).
 
-        The type definition or default value can be omitted but not both:
+        The type definition or default value can be omitted, but not both:
 
         ```mint
         // Type inferred from the default value
@@ -70,7 +70,7 @@ module Lessons {
         property name : String
         ```
 
-        If the passed property doesn't match its given type then you will get
+        If the passed property doesn't match its given type, then you will get
         a compile error.
         MARKDOWN
     }

--- a/source/Lessons/Components/06-Properties.mint
+++ b/source/Lessons/Components/06-Properties.mint
@@ -70,7 +70,7 @@ module Lessons {
         property name : String
         ```
 
-        If the passed property doesn't match it's given type then you will get
+        If the passed property doesn't match its given type then you will get
         a compile error.
         MARKDOWN
     }

--- a/source/Lessons/Components/08-State.mint
+++ b/source/Lessons/Components/08-State.mint
@@ -73,7 +73,7 @@ module Lessons {
 
         The state can be moved forward using the `next` keyword.
 
-        As an exercise, you can add an other button to hide the text!
+        As an exercise, you can add another button to hide the text!
         MARKDOWN
     }
 }

--- a/source/Lessons/Components/08-State.mint
+++ b/source/Lessons/Components/08-State.mint
@@ -53,7 +53,7 @@ module Lessons {
         Sometimes you need to have some data for a component to describe it's
         internal state.
 
-        For that you can use the `state` keyword:
+        For that, you can use the `state` keyword:
 
         ```mint
         component Main {
@@ -73,7 +73,7 @@ module Lessons {
 
         The state can be moved forward using the `next` keyword.
 
-        As an exercise you can add an other button to hide the text!
+        As an exercise, you can add an other button to hide the text!
         MARKDOWN
     }
 }

--- a/source/Lessons/Components/09-References.mint
+++ b/source/Lessons/Components/09-References.mint
@@ -71,7 +71,7 @@ module Lessons {
       contents:
         <<#MARKDOWN
         Sometimes it's necessary to access elements or components in a component
-        for a number of reasons. To do that you can use the `as name` notation:
+        for a number of reasons. To do that, you can use the `as name` notation:
 
         ```mint
         <input as input/>

--- a/source/Lessons/ControlExpressions/01-If.mint
+++ b/source/Lessons/ControlExpressions/01-If.mint
@@ -59,7 +59,7 @@ module Lessons {
         ],
       contents:
         <<#MARKDOWN
-        As most other languages Mint has a structrue to return different
+        As most other languages Mint has a structure to return different
         values based on some condition.
 
         It looks like this:
@@ -76,7 +76,7 @@ module Lessons {
         statement, and because of this both branches need to return something
         and those need to be of the same type.
 
-        With this information you should be able update the code to display the
+        With this information you should be able to update the code to display the
         correct button based on the `userLoggedIn` state.
         MARKDOWN
     }

--- a/source/Lessons/ControlExpressions/01-If.mint
+++ b/source/Lessons/ControlExpressions/01-If.mint
@@ -59,7 +59,7 @@ module Lessons {
         ],
       contents:
         <<#MARKDOWN
-        As most other languages, Mint has a structure to return different
+        As most other languages, Mint has a construct to return different
         values based on some condition.
 
         It looks like this:

--- a/source/Lessons/ControlExpressions/01-If.mint
+++ b/source/Lessons/ControlExpressions/01-If.mint
@@ -59,7 +59,7 @@ module Lessons {
         ],
       contents:
         <<#MARKDOWN
-        As most other languages Mint has a structure to return different
+        As most other languages, Mint has a structure to return different
         values based on some condition.
 
         It looks like this:
@@ -72,11 +72,11 @@ module Lessons {
         }
         ```
 
-        Unlike in some languages `if` in Mint is an expression and not a
+        Unlike in some languages, `if` in Mint is an expression and not a
         statement, and because of this both branches need to return something
         and those need to be of the same type.
 
-        With this information you should be able to update the code to display the
+        With this information, you should be able to update the code to display the
         correct button based on the `userLoggedIn` state.
         MARKDOWN
     }

--- a/source/Lessons/ControlExpressions/02-For.mint
+++ b/source/Lessons/ControlExpressions/02-For.mint
@@ -73,7 +73,7 @@ module Lessons {
         ],
       contents:
         <<#MARKDOWN
-        As most other languages, Mint has a structure to iterate over certain
+        As most other languages, Mint has a construct to iterate over certain
         data structures.
 
         It's the `for` block, and it looks like this:
@@ -88,7 +88,7 @@ module Lessons {
         statement, and because of this it returns an `Array(item)` where
         `item` is the type of the last `expression`.
 
-        Currently, it only can iterate through these types: `Array(item)`, `Set(item)`,
+        Currently, it can iterate through these types: `Array(item)`, `Set(item)`,
         and `Map(key,value)`.
 
         ## Filtering using `when`

--- a/source/Lessons/ControlExpressions/02-For.mint
+++ b/source/Lessons/ControlExpressions/02-For.mint
@@ -73,7 +73,7 @@ module Lessons {
         ],
       contents:
         <<#MARKDOWN
-        As most other languages Mint has a structrue to iterate over certain
+        As most other languages Mint has a structure to iterate over certain
         data structures.
 
         It's the `for` block and it looks like this:
@@ -105,7 +105,7 @@ module Lessons {
         }
         ```
 
-        Let's display the links of the cat videos usin a `for` expression.
+        Let's display the links of the cat videos using a `for` expression.
         MARKDOWN
     }
 }

--- a/source/Lessons/ControlExpressions/02-For.mint
+++ b/source/Lessons/ControlExpressions/02-For.mint
@@ -73,10 +73,10 @@ module Lessons {
         ],
       contents:
         <<#MARKDOWN
-        As most other languages Mint has a structure to iterate over certain
+        As most other languages, Mint has a structure to iterate over certain
         data structures.
 
-        It's the `for` block and it looks like this:
+        It's the `for` block, and it looks like this:
 
         ```mint
         for (item of iterable) {
@@ -84,11 +84,11 @@ module Lessons {
         }
         ```
 
-        Unlike in some languages `for` in Mint is an expression and not a
+        Unlike in some languages, `for` in Mint is an expression and not a
         statement, and because of this it returns an `Array(item)` where
         `item` is the type of the last `expression`.
 
-        Currently it only can iterate through these types: `Array(item)`, `Set(item)`,
+        Currently, it only can iterate through these types: `Array(item)`, `Set(item)`,
         and `Map(key,value)`.
 
         ## Filtering using `when`

--- a/source/Lessons/ControlExpressions/03-Case.mint
+++ b/source/Lessons/ControlExpressions/03-Case.mint
@@ -90,7 +90,7 @@ module Lessons {
         The `case` expression is more powerful than this simple example shows
         and will be covering it in other lessons.
 
-        As an exercise you can add the branches for `3` and `4`.
+        As an exercise, you can add the branches for `3` and `4`.
         MARKDOWN
     }
 }

--- a/source/Lessons/ControlExpressions/03-Case.mint
+++ b/source/Lessons/ControlExpressions/03-Case.mint
@@ -88,7 +88,7 @@ module Lessons {
         ```
 
         The `case` expression is more powerful than this simple example shows
-        and will be covering it in other lessons.
+        and we will be covering it in other lessons.
 
         As an exercise, you can add the branches for `3` and `4`.
         MARKDOWN

--- a/source/Lessons/Html/01-Tags.mint
+++ b/source/Lessons/Html/01-Tags.mint
@@ -45,14 +45,14 @@ module Lessons {
       contents:
         <<#MARKDOWN
         Mint mostly supports writing HTML as is and you can use any tags you
-        would like. It uses a **virtual dom** to render the defined tags to
-        the document (currenty [Preact](https://preactjs.com/) but it might
+        would like. It uses a **virtual DOM** to render the defined tags to
+        the document (currently [Preact](https://preactjs.com/), but it might
         change in the future).
 
         There are some changes and additions which you should be aware of:
 
-        * Text needs to be sepcified as strings, this is because it allows you
-          to control whitespace expilictly.
+        * Text needs to be specified as strings, this is because it allows you
+          to control whitespace explicitly.
 
         * You can use some expressions inside the HTML tags, like `if` and
           `for`.
@@ -61,8 +61,8 @@ module Lessons {
 
         Attributes are usually strings but there are some exceptions:
 
-        * Anything starting with `on` are considered events a take functions
-          instead of strings `onClick={() { Window.alert("Hello!") }}`.
+        * Anything starting with `on` is considered an event, which takes
+          a function instead of a string (`onClick={() { Window.alert("Hello!") }}`).
 
         * `readonly`, `disabled` and `checked` takes a `Bool`
           (`checked={true}`).

--- a/source/Lessons/Html/01-Tags.mint
+++ b/source/Lessons/Html/01-Tags.mint
@@ -57,9 +57,9 @@ module Lessons {
         * You can use some expressions inside the HTML tags, like `if` and
           `for`.
 
-        * Attributes cannot be naked so they must have a value.
+        * Attributes cannot be naked, so they must have a value.
 
-        Attributes are usually strings but there are some exceptions:
+        Attributes are usually strings, but there are some exceptions:
 
         * Anything starting with `on` is considered an event, which takes
           a function instead of a string (`onClick={() { Window.alert("Hello!") }}`).

--- a/source/Lessons/Html/02-Events.mint
+++ b/source/Lessons/Html/02-Events.mint
@@ -37,9 +37,9 @@ module Lessons {
         * `Function(Html.Event, a)`
         * `Function(a)`
 
-        In regular JavaScript there are multiple event objects with different
+        In regular JavaScript, there are multiple event objects with different
         values. [`Html.Event`](https://www.mint-lang.com/api/records/Html.Event)
-        is a record which contains normalized values so it can be used in all
+        is a record which contains normalized values, so it can be used in all
         event handlers.
         MARKDOWN
     }

--- a/source/Lessons/Html/03-Inline-Styles.mint
+++ b/source/Lessons/Html/03-Inline-Styles.mint
@@ -33,7 +33,7 @@ module Lessons {
         ],
       contents:
         <<#MARKDOWN
-        One of the was you can define CSS for a HTML tag using inline styles.
+        You can define CSS for an HTML tag using inline styles.
 
         Inline styles can be defined using the `style` attribute. It takes
         either CSS string or a `Map(String, String)` of CSS values:

--- a/source/Lessons/Html/04-Fragments.mint
+++ b/source/Lessons/Html/04-Fragments.mint
@@ -30,7 +30,7 @@ module Lessons {
         into for example a `div`. In those cases, you can use a **HTML
         fragment**.
 
-        It's written as an HTML tag without a tagname:
+        It's written as an HTML tag without a tag name:
 
         ```mint
         <>

--- a/source/Lessons/Html/04-Fragments.mint
+++ b/source/Lessons/Html/04-Fragments.mint
@@ -27,7 +27,7 @@ module Lessons {
       contents:
         <<#MARKDOWN
         There are cases where you don't want to wrap multiple `HTML` elements
-        into for example a `div`. In those cases you can use a **HTML
+        into for example a `div`. In those cases, you can use a **HTML
         fragment**.
 
         It's written as an HTML tag without a tagname:
@@ -41,7 +41,7 @@ module Lessons {
         ```
 
         HTML fragments can only have one attribute `key` which is used to
-        identify the fragment in specific cases which we will cover later.
+        identify the fragment in specific cases, which we will cover later.
         MARKDOWN
     }
 }

--- a/source/Lessons/Language/01-Types.mint
+++ b/source/Lessons/Language/01-Types.mint
@@ -10,7 +10,7 @@ module Lessons {
         Mint is a strongly typed programming language, which means that you will
         encounter a lot of type definitions.
 
-        Syntax wise a type definition consists of an identifier starting with a
+        Syntax wise, a type definition consists of an identifier starting with a
         capital letter, and followed by letters and numbers.
 
         A type basically gives a name to a value conforming to a specific data
@@ -36,7 +36,7 @@ module Lessons {
         These kinds of types are called composite types because the data
         structure they describe are composed of multiple types.
 
-        Types appear in Mint code in multiple places usually preceded by a
+        Types appear in Mint code in multiple places, usually preceded by a
         colon:
 
         ```mint

--- a/source/Lessons/Language/01-Types.mint
+++ b/source/Lessons/Language/01-Types.mint
@@ -13,8 +13,7 @@ module Lessons {
         Syntax wise, a type definition consists of an identifier starting with a
         capital letter, and followed by letters and numbers.
 
-        A type basically gives a name to a value conforming to a specific data
-        structure.
+        A type gives a name to a value conforming to a specific data structure.
 
         ```mint
         "Hello World!" // The type of this value is `String`

--- a/source/Lessons/Language/01-Types.mint
+++ b/source/Lessons/Language/01-Types.mint
@@ -17,10 +17,10 @@ module Lessons {
         structure.
 
         ```mint
-        "Hello World!" // Type type of this value is `String`
+        "Hello World!" // The type of this value is `String`
         ```
 
-        A type can have **type variables**. These variables makes the type
+        A type can have **type variables**. These variables make the type
         [polymorphic](https://en.wikipedia.org/wiki/Polymorphism_(computer_science)),
         which means that the type can be used with other types
         instead of the type variable.
@@ -33,10 +33,10 @@ module Lessons {
         Maybe(String)
         ```
 
-        These kind of types are called composite types because the data
+        These kinds of types are called composite types because the data
         structure they describe are composed of multiple types.
 
-        Types appear in Mint code in multiple places usually preceeded by a
+        Types appear in Mint code in multiple places usually preceded by a
         colon:
 
         ```mint

--- a/source/Lessons/Language/02-Literals.mint
+++ b/source/Lessons/Language/02-Literals.mint
@@ -18,7 +18,7 @@ module Lessons {
         ```
         ## Number
 
-        Represents a Number. In Mint all numbers are floats.
+        Represents a Number. In Mint, all numbers are floats.
 
         ```mint
         3.14

--- a/source/Lessons/Language/02-Literals.mint
+++ b/source/Lessons/Language/02-Literals.mint
@@ -28,7 +28,7 @@ module Lessons {
 
         ## Regexp
 
-        Regular expressions are represented by the `Regex` type.
+        Regular expressions are represented by the `Regexp` type.
 
         ```mint
         /foo|bar/

--- a/source/Lessons/Language/02-Literals.mint
+++ b/source/Lessons/Language/02-Literals.mint
@@ -9,7 +9,7 @@ module Lessons {
         <<#MARKDOWN
         ## Boolean
 
-        Represents the Boolean type. It has two possible values `true` and
+        Represents the `Boolean` type. It has two possible values `true` and
         `false`.
 
         ```mint
@@ -18,7 +18,7 @@ module Lessons {
         ```
         ## Number
 
-        Represents a Number. In Mint, all numbers are floats.
+        Represents a `Number`. In Mint, all numbers are floats.
 
         ```mint
         3.14

--- a/source/Lessons/Language/03-Strings.mint
+++ b/source/Lessons/Language/03-Strings.mint
@@ -9,7 +9,7 @@ module Lessons {
         <<#MARKDOWN
         A `String` represents a sequence of characters.
 
-        Strings are created with string literals using qoutes `""`:
+        Strings are created with string literals using quotes `""`:
 
         ```mint
         "A single line string!"
@@ -26,7 +26,7 @@ module Lessons {
         "Third line" == "First lineSecond lineThird line"
         ```
 
-        Strings can be concanated with the `+` operator:
+        Strings can be concatenated with the `+` operator:
 
         ```mint
         ("Hello" + " World" + "!") == "Hello World!"

--- a/source/Lessons/Language/03-Strings.mint
+++ b/source/Lessons/Language/03-Strings.mint
@@ -41,9 +41,9 @@ module Lessons {
         "Hello \#{world}!" == "Hello World!"
         ```
 
-        Since Mint is a strongly typed language you can only interpolate other
+        Since Mint is a strongly typed language, you can only interpolate other
         `String` or `Number` typed values (numbers are implicitly converted to
-        string). If you try to use something else you will get a nice error
+        string). If you try to use something else, you will get a nice error
         message.
         MARKDOWN
     }

--- a/source/Lessons/Language/04-Arrays.mint
+++ b/source/Lessons/Language/04-Arrays.mint
@@ -46,7 +46,7 @@ module Lessons {
         ```
 
         We can access an arrays item at a given index using the bracket
-        notiation:
+        notation:
 
         ```mint
         let array =
@@ -56,7 +56,7 @@ module Lessons {
         ```
 
         When accessing an item this way the type of the item will be `Maybe(a)`
-        where a is the type of item in the array. This is so because there might
+        where a is the type of the item in the array. This is so because there might
         not be an item at that index.
         MARKDOWN
     }

--- a/source/Lessons/Language/04-Arrays.mint
+++ b/source/Lessons/Language/04-Arrays.mint
@@ -37,7 +37,7 @@ module Lessons {
         ["A", "B", "C"]
         ```
 
-        You can define the type of an array using the of keyword. It is useful
+        You can define the type of an array using the `of` keyword. It is useful
         for defining the type of an empty array:
 
         ```mint
@@ -55,8 +55,8 @@ module Lessons {
         array[0] == Maybe::Just(1)
         ```
 
-        where a is the type of the item in the array. This is so because there might
         When accessing an item this way, the type of the item will be `Maybe(a)`
+        where `a` is the type of the item in the array. This is so because there might
         not be an item at that index.
         MARKDOWN
     }

--- a/source/Lessons/Language/04-Arrays.mint
+++ b/source/Lessons/Language/04-Arrays.mint
@@ -55,8 +55,8 @@ module Lessons {
         array[0] == Maybe::Just(1)
         ```
 
-        When accessing an item this way the type of the item will be `Maybe(a)`
         where a is the type of the item in the array. This is so because there might
+        When accessing an item this way, the type of the item will be `Maybe(a)`
         not be an item at that index.
         MARKDOWN
     }

--- a/source/Lessons/Language/05-Tuples.mint
+++ b/source/Lessons/Language/05-Tuples.mint
@@ -27,14 +27,14 @@ module Lessons {
         ],
       contents:
         <<#MARKDOWN
-        Tuple is a data structure which contains a fixed set values, where each
+        Tuple is a data structure which contains a fixed set of values, where each
         value can have a different type.
 
-        * they are useful when you don't want to declare a record
+        * tuples are useful when you don't want to declare a record
         * they can contain any number of items
-        * their items can be destuctured and matched against
+        * their items can be destructured and matched against
 
-        Tuples can be created by specifiting its items separated by commas
+        A tuple can be created by specifying its items separated by commas
         inside curly brackets `{...}`
 
         ```mint
@@ -49,7 +49,7 @@ module Lessons {
         third is a `Bool`.
 
         We can access a tuples item at a given index using the bracket
-        notiation:
+        notation:
 
         ```mint
         let tuple =

--- a/source/Lessons/Language/05-Tuples.mint
+++ b/source/Lessons/Language/05-Tuples.mint
@@ -44,7 +44,7 @@ module Lessons {
         The type of a tuple is `Tuple(...)` where each parameter is an item of
         a tuple.
 
-        For example the type `Tuple(String, Number, Bool)` represents a tuple
+        For example, the type `Tuple(String, Number, Bool)` represents a tuple
         where the first element is a `String` the second is a `Number` the
         third is a `Bool`.
 

--- a/source/Lessons/Language/05-Tuples.mint
+++ b/source/Lessons/Language/05-Tuples.mint
@@ -27,7 +27,7 @@ module Lessons {
         ],
       contents:
         <<#MARKDOWN
-        Tuple is a data structure which contains a fixed set of values, where each
+        `Tuple` is a data structure which contains a fixed set of values, where each
         value can have a different type.
 
         * tuples are useful when you don't want to declare a record

--- a/source/Lessons/Language/05-Tuples.mint
+++ b/source/Lessons/Language/05-Tuples.mint
@@ -41,8 +41,8 @@ module Lessons {
         {"First Value", 10, true}
         ```
 
-        The type of a tuple is `Tuple(...)` where each parameter is an item of
-        a tuple.
+        The type of a tuple is `Tuple(...)` where each parameter, in that order, is
+        an item of the tuple.
 
         For example, the type `Tuple(String, Number, Bool)` represents a tuple
         where the first element is a `String` the second is a `Number` the

--- a/source/Lessons/Language/07-Functions.mint
+++ b/source/Lessons/Language/07-Functions.mint
@@ -32,7 +32,7 @@ module Lessons {
         ],
       contents:
         <<#MARKDOWN
-        Functions plays a central role in Mint. For instance, every component
+        Functions play a central role in Mint. For instance, every component
         **must** have a `render` function. That's why it's crucial you have a
         good under standing of how they work.
 

--- a/source/Lessons/Language/07-Functions.mint
+++ b/source/Lessons/Language/07-Functions.mint
@@ -34,7 +34,7 @@ module Lessons {
         <<#MARKDOWN
         Functions play a central role in Mint. For instance, every component
         **must** have a `render` function. That's why it's crucial you have a
-        good under standing of how they work.
+        good understanding of how they work.
 
         In Mint, every function starts with the `fun` keyword then name (a
         lowercase letter followed by letters and numbers). After the name (or
@@ -70,7 +70,7 @@ module Lessons {
         ```
 
         Let's give it a shot! Declare a `name` variable in your `render`
-        function and replace the currently hardcoded greeting.
+        function and replace the currently hard-coded greeting.
         MARKDOWN
     }
 }

--- a/source/Lessons/Language/08-Function-Arguments.mint
+++ b/source/Lessons/Language/08-Function-Arguments.mint
@@ -48,7 +48,7 @@ module Lessons {
         Functions can have arguments. Arguments must start with a lowercase
         letter and can contain only letters and numbers.
 
-        Arguments come after the name of the function separated by commas and
+        Arguments come after the name of the function, separated by commas and
         enclosed by parentheses:
 
         ```mint

--- a/source/Lessons/Language/08-Function-Arguments.mint
+++ b/source/Lessons/Language/08-Function-Arguments.mint
@@ -67,7 +67,7 @@ module Lessons {
         ```
 
         Let's change the `greet` function to take an argument for the name and
-        use that in the return value! Don't forget to add a default argument
+        use that in the return value! Don't forget to add a default value
         to make both calls work and uncomment the second greeting!
         MARKDOWN
     }

--- a/source/Lessons/Language/08-Function-Arguments.mint
+++ b/source/Lessons/Language/08-Function-Arguments.mint
@@ -45,8 +45,8 @@ module Lessons {
         ],
       contents:
         <<#MARKDOWN
-        Functions can have arguments. Arguments must start with a lowercase
-        letter and can contain only letters and numbers.
+        Functions can have arguments. Argument names must start with a
+        lowercase letter and can contain only letters and numbers.
 
         Arguments come after the name of the function, separated by commas and
         enclosed by parentheses:

--- a/source/Lessons/Language/09-Anonymous-Functions.mint
+++ b/source/Lessons/Language/09-Anonymous-Functions.mint
@@ -30,7 +30,7 @@ module Lessons {
       contents:
         <<#MARKDOWN
         Anonymous functions look like regular functions but without the `fun`
-        keyword and the name and they are usually used in event handlers or as
+        keyword and the name, and they are usually used in event handlers or as
         arguments to other function calls:
 
         ```mint

--- a/source/Lessons/Language/10-Function-Calls.mint
+++ b/source/Lessons/Language/10-Function-Calls.mint
@@ -31,7 +31,7 @@ module Lessons {
       contents:
         <<#MARKDOWN
         You can call on any value using parentheses `()` provided that it's type
-        is `Function(...)`. Call arguments go inside the parenthese separated by
+        is `Function(...)`. Call arguments go inside the parentheses separated by
         commas.
 
         ```mint
@@ -40,13 +40,13 @@ module Lessons {
         ```
 
         The `Function` type is a special type because it describes a function
-        instead of data. The type arguments of the type represents the types
+        instead of data. The type arguments of the type represent the types
         of the arguments of the actual function itself and the **last argument**
         represents the **return type** of the function.
 
         ```mint
         // Function(String, String)
-        fun greet (string : String) : String { ... }
+        fun greet (name : String) : String { ... }
 
         // Function(Function(a, b), Array(a), Array(b))
         fun map (interator : Function(a, b), array : Array(a)) : Array(b) { ... }

--- a/source/Lessons/Language/11-Enums.mint
+++ b/source/Lessons/Language/11-Enums.mint
@@ -63,12 +63,12 @@ module Lessons {
 
         ```mint
         enum User {
-          User::LoggedIn(String)
-          User::Visitor
+          LoggedIn(String)
+          Visitor
         }
         ```
 
-        You can create a value of an enum option by using it's name and option:
+        You can create a value of an enum option by using its name and option:
 
         ```mint
         User::LoggedIn("Joe")

--- a/source/Lessons/Language/11-Enums.mint
+++ b/source/Lessons/Language/11-Enums.mint
@@ -55,11 +55,11 @@ module Lessons {
         ],
       contents:
         <<#MARKDOWN
-        In Mint **enums** represents [Algebraic Data Types](https://en.wikipedia.org/wiki/Algebraic_data_type),
-        with them it's possible to describe data which contains different types
+        In Mint, **enums** represents [Algebraic Data Types](https://en.wikipedia.org/wiki/Algebraic_data_type),
+        with them, it's possible to describe data which contains different types
         of values (called options).
 
-        For example a type for a logged in state can be written as two options:
+        For example, a type for a logged in state can be written as two options:
 
         ```mint
         enum User {
@@ -74,7 +74,7 @@ module Lessons {
         User::LoggedIn("Joe")
         ```
 
-        As an exercise change the given example to show "Joe" as the logged in
+        As an exercise, change the given example to show "Joe" as the logged in
         user.
         MARKDOWN
     }

--- a/source/Lessons/Language/12-Generic-Enums.mint
+++ b/source/Lessons/Language/12-Generic-Enums.mint
@@ -40,7 +40,7 @@ module Lessons {
         ],
       contents:
         <<#MARKDOWN
-        Enums can be generic meaning that you can specify relationships using
+        Enums can be generic, meaning that you can specify relationships using
         type variables.
 
         An example for this is the `Result` enum:

--- a/source/Lessons/Language/13-Records.mint
+++ b/source/Lessons/Language/13-Records.mint
@@ -82,7 +82,7 @@ module Lessons {
         }
         ```
 
-        An other way is to use a record constructor:
+        Another way is to use a record constructor:
 
         ```mint
         User("john@doe.com", "John Doe", 1) == {

--- a/source/Lessons/Language/13-Records.mint
+++ b/source/Lessons/Language/13-Records.mint
@@ -82,7 +82,7 @@ module Lessons {
         }
         ```
 
-        An other was is to use a record constructor:
+        An other way is to use a record constructor:
 
         ```mint
         User("john@doe.com", "John Doe", 1) == {
@@ -92,7 +92,7 @@ module Lessons {
         }
         ```
 
-        You can access a records fields using the `.` notation:
+        You can access a record's fields using the `.` notation:
 
         ```mint
         user.name == "John Doe"

--- a/source/Lessons/Language/13-Records.mint
+++ b/source/Lessons/Language/13-Records.mint
@@ -98,7 +98,7 @@ module Lessons {
         user.name == "John Doe"
         ```
 
-        As an exercise add an `age` field to the record!
+        As an exercise, add an `age` field to the record!
         MARKDOWN
     }
 }

--- a/source/Lessons/Language/14-Updating-Records.mint
+++ b/source/Lessons/Language/14-Updating-Records.mint
@@ -78,8 +78,8 @@ module Lessons {
         { user | name: "Jane Doe" }
         ```
 
-        It copies all of the not specified fields of the base record and sets
-        the specified fileds.
+        It copies all the not specified fields of the base record and sets
+        the specified fields.
 
         You can update more than one field:
 

--- a/source/Lessons/Language/14-Updating-Records.mint
+++ b/source/Lessons/Language/14-Updating-Records.mint
@@ -69,10 +69,10 @@ module Lessons {
         ],
       contents:
         <<#MARKDOWN
-        Since values are immutable in Mint you cannot modify a record directly,
+        Since values are immutable in Mint, you cannot modify a record directly,
         but only create a new record with the modified fields.
 
-        To achieve that you can use the record update syntax:
+        To achieve that, you can use the record update syntax:
 
         ```mint
         { user | name: "Jane Doe" }
@@ -87,7 +87,7 @@ module Lessons {
         { user | name: "Jane Doe", email: "jane@doe.com" }
         ```
 
-        As an exercise update the `email` field of the record!
+        As an exercise, update the `email` field of the record!
         MARKDOWN
     }
 }

--- a/source/Lessons/Language/15-Constants.mint
+++ b/source/Lessons/Language/15-Constants.mint
@@ -28,14 +28,14 @@ module Lessons {
         running, they can be defined for top level entities like `module`,
         `component`, `suite` or `store`.
 
-        They can only contain uppercase letters and underscores and you can use
-        the `const` keyword to define them:
+        They can only contain uppercase letters and underscores. Use the
+        `const` keyword to define them:
 
         ```mint
         const PI = 3.14159265359
         ```
 
-        Also they can be accessed using their name.
+        They can be accessed using their name.
 
         ```mint
         PI * 2 // 6.28318530718

--- a/source/Lessons/Language/16-Modules.mint
+++ b/source/Lessons/Language/16-Modules.mint
@@ -42,8 +42,8 @@ module Lessons {
         Greeter.greet("Joe") /* "Hello Joe" */
         ```
 
-        You can omit the name of the module if you are calling a function from
-        another function in the same module:
+        You can omit the name of the module if you are calling the function from
+        inside the module:
 
         ```mint
         module Greeter {

--- a/source/Lessons/Language/16-Modules.mint
+++ b/source/Lessons/Language/16-Modules.mint
@@ -36,7 +36,7 @@ module Lessons {
         They are usually used to gather functions that relate to a specific
         type (like `String` or `Number`).
 
-        You can call the functions of a module by using the modules name:
+        You can call the functions of a module by using the module's name:
 
         ```mint
         Greeter.greet("Joe") /* "Hello Joe" */
@@ -74,7 +74,7 @@ module Lessons {
         }
         ```
 
-        It's useful if you want to extend modules in the standar library.
+        It's useful if you want to extend modules in the standard library.
         MARKDOWN
     }
 }

--- a/source/Lessons/Language/16-Modules.mint
+++ b/source/Lessons/Language/16-Modules.mint
@@ -57,7 +57,7 @@ module Lessons {
         }
         ```
 
-        Modules are _open_ meaning that you can define additional functions in
+        Modules are _open_, meaning that you can define additional functions in
         different places:
 
         ```mint


### PR DESCRIPTION
I have read through the [tutorial](https://tutorial.mint-lang.com) again and have applied some corrections on the way.

The commits are sorted by category of the fix. It is probably most efficient to read them commit by commit.

* The first are obvious typos
* The next three are suggestions by [LanguageTool](https://languagetool.org/services), I agree with them
* The fourth wraps some things in inline code
*  The sixth is a typo which LanguageTool doesn't report, but I think it is one
* The seventh are reformulations, not always fixes
